### PR TITLE
feat: Load Turkish lemma dictionary from embedded resource file (#74)

### DIFF
--- a/python/durak/_durak_core.pyi
+++ b/python/durak/_durak_core.pyi
@@ -59,17 +59,26 @@ def tokenize_with_offsets(text: str) -> list[tuple[str, int, int]]:
 def lookup_lemma(word: str) -> str | None:
     """Perform exact dictionary lookup for lemmatization.
 
-    Tier 1 lemmatization: Fast exact lookup in the internal dictionary.
+    Tier 1 lemmatization: Fast exact lookup in the embedded Turkish lemma dictionary.
+    The dictionary contains 1,362+ inflected forms mapped to their base lemmas,
+    loaded from resources/tr/lemmas/turkish_lemma_dict.txt at build time.
+
+    Coverage:
+    - High-frequency nouns with case/plural suffixes
+    - Common verb inflections (tense, aspect, person markers)
+    - Systematic vowel harmony patterns (front/back vowel classes)
 
     Args:
-        word: The word to lemmatize
+        word: The inflected word to lemmatize
 
     Returns:
-        The lemma if found in dictionary, None otherwise
+        The base lemma if found in dictionary, None otherwise
 
     Examples:
         >>> lookup_lemma("kitaplar")
         'kitap'
+        >>> lookup_lemma("geliyorum")
+        'gel'
         >>> lookup_lemma("unknown")
         None
     """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,27 @@ mod tests {
     }
 
     #[test]
+    fn test_lookup_lemma_with_resource_dict() {
+        // Test lookups from embedded turkish_lemma_dict.txt
+        let test_cases = vec![
+            ("kitaplar", "kitap"),
+            ("evler", "ev"),
+            ("geliyorum", "gel"),
+            ("aldım", "al"),
+            ("adamlar", "adam"),
+            ("anaları", "ana"),
+        ];
+
+        for (inflected, expected_lemma) in test_cases {
+            let result = lookup_lemma(inflected);
+            assert_eq!(result, Some(expected_lemma.to_string()),
+                "lookup_lemma('{}') should return '{}', got: {:?}",
+                inflected, expected_lemma, result
+            );
+        }
+    }
+
+    #[test]
     fn test_lookup_lemma_oov_words() {
         // Out-of-vocabulary words should return None
         let oov_words = vec!["bilgisayar", "internet", "xyz123", "nonexistent"];


### PR DESCRIPTION
## Summary

Implements #74 - Replaces hardcoded 3-entry mock dictionary with a production-ready embedded Turkish lemma dictionary.

## Changes

- ✅ Add `LEMMA_DICT_DATA` static from `resources/tr/lemmas/turkish_lemma_dict.txt`
- ✅ Update `get_lemma_dict()` to parse TSV format (`inflected<TAB>lemma`)
- ✅ Load 1,362+ inflected forms → lemmas at build time (zero-overhead)
- ✅ Add comprehensive tests for dictionary loading and lookups
- ✅ Update Python type stubs with accurate documentation

## Coverage

The embedded dictionary now includes:
- **High-frequency nouns** with case/plural suffixes (kitap, ev, adam, etc.)
- **Common verb inflections** with tense/aspect/person markers (gel, al, git, etc.)
- **Systematic vowel harmony patterns** (front/back vowel classes)
- **1,362 total entries** (vs. previous 3-entry PoC mock)

## Testing

```bash
PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --lib
```

All tests pass:
- ✅ `test_lookup_lemma_with_resource_dict` - Real dictionary lookups
- ✅ `test_lemma_dict_loading` - Dictionary size and content validation
- ✅ `test_lookup_lemma_high_frequency_nouns` - Noun inflections
- ✅ `test_lookup_lemma_high_frequency_verbs` - Verb inflections

## Related Issues

- Closes #74
- Part of Tier 1 lemmatization strategy (#6)
- Supports future evaluation framework (#56)