### PR TITLE
fix: Update benchmark script to use process_text API (#51)

### DIFF
--- a/benchmarks/benchmark_rust_vs_python.py
+++ b/benchmarks/benchmark_rust_vs_python.py
@@ -106,11 +106,11 @@ def main():
     print("\n4. Complete Processing Pipeline")
     print("-" * 70)
 
-    pipeline = durak.Pipeline(
-        ["clean", "tokenize", "remove_stopwords", "normalize"]
-    )
+    # Using process_text convenience function (updated API)
+    def pipeline_func(text):
+        return durak.process_text(text, remove_stopwords=True, rejoin_suffixes=True)
 
-    pipeline_time = benchmark(pipeline, large_text, iterations=100)
+    pipeline_time = benchmark(pipeline_func, large_text, iterations=100)
     print(f"Full pipeline: {pipeline_time:.4f} ms per call")
 
     print("\n" + "=" * 70)


### PR DESCRIPTION
## Problem

The benchmark script was using the old string-based Pipeline API:
```python
pipeline = durak.Pipeline(["clean", "tokenize", "remove_stopwords", "normalize"])
```

This caused a `TypeError: 'str' object is not callable` because the Pipeline class expects callable objects, not strings.

## Solution

Updated benchmark #4 to use the `process_text` convenience function instead:
```python
def pipeline_func(text):
    return durak.process_text(text, remove_stopwords=True, rejoin_suffixes=True)
```

This uses the current API and should run without errors.

## Testing

- ✅ Syntax validation passed (`python3 -m py_compile`)
- 🔄 Full benchmark run requires `maturin develop` (CI will verify)

Closes #51