### PR TITLE
Refactor: Rename bug test to verfiy correct backend flag handling

### DIFF
--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -83,18 +83,14 @@ def test_configuration_flags_stored() -> None:
     assert not normalizer.handle_turkish_i
 
 
-def test_bug_lowercase_flags_ignored_by_backend() -> None:
-    """
-    BUG #39: The Rust backend currently ignores the lowercase flag.
-    Even when lowercase=False, fast_normalize is called with default behavior.
-    TODO: Fix backend to respect configuration flags.
-    """
+def test_configuration_flags_passed_by_backend() -> None:
+    """Verify that configuration flags are correctly passed to the Rust backend."""
 
-    normalizer = Normalizer(lowercase=False)
+    normalizer = Normalizer(lowercase=False, handle_turkish_i=True)
 
     with patch("durak.normalizer.fast_normalize") as mock_fast:
         normalizer("TEST")
-        mock_fast.assert_called()
+        mock_fast.assert_called_with("TEST", False, True)
 
 
 # --- Rust Fallback Test --- #


### PR DESCRIPTION
@ada-cinar Quick update: I pulled the latest changes from `main` and realized the Rust backend fix (Issue #138) is actually already present in the codebase!

Since the backend already accepts the 3 arguments, I updated the test `test_bug_lowercase_flags_ignored_by_backend` to be a standard verification test named `test_configuration_flags_passed_to_backend`.

This means Issue #138 is effectively resolved. I've updated the test suite to reflect this. Ready for a final check! 🛠️